### PR TITLE
Fix asset paths to respect base URL

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,15 +7,15 @@
   <meta name="description" content="{{ page.description | default: site.description }}">
 
   <!-- Styles -->
-  <link rel="stylesheet" href="{{ '/assets/core.css' | absolute_url }}">
+  <link rel="stylesheet" href="{{ '/assets/core.css' | relative_url }}">
 
   <!-- Favicon -->
-  <link rel="icon" href="{{ '/assets/favicon.png' | absolute_url }}">
+  <link rel="icon" href="{{ '/assets/favicon.png' | relative_url }}">
 
   <!-- Open Graph -->
   <meta property="og:title" content="{{ page.title | default: site.title }}">
   <meta property="og:description" content="{{ page.description | default: site.description }}">
-  <meta property="og:image" content="{{ '/assets/book_logo.png' | absolute_url }}">
+  <meta property="og:image" content="{{ '/assets/book_logo.png' | relative_url }}">
   <meta property="og:url" content="{{ page.url | absolute_url }}">
   <meta property="og:type" content="website">
 
@@ -23,5 +23,5 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="{{ page.title | default: site.title }}">
   <meta name="twitter:description" content="{{ page.description | default: site.description }}">
-  <meta name="twitter:image" content="{{ '/assets/book_logo.png' | absolute_url }}">
+  <meta name="twitter:image" content="{{ '/assets/book_logo.png' | relative_url }}">
 </head>


### PR DESCRIPTION
## Summary
- ensure local asset links use `relative_url` so CSS and images load under base URL

## Testing
- `bundle exec jekyll build` *(fails: 403 "Forbidden" downloading remote theme)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b0c869e0832c8bf5eea0383f3be6